### PR TITLE
remove linking to graphics libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ LIBRARY= Hector
 LIBFULLNAME = $(addprefix lib,$(addsuffix $(LEXT),$(LIBRARY))) 
 # ROOTCFLAGS & ROOTLIBS  flags needed from ROOT for the compilation command
 ROOTCFLAGS= -fPIC $(shell root-config --cflags) 
-ROOTLIBS= $(shell root-config --libs --glibs)
+ROOTLIBS= $(shell root-config --libs)
 # HEADERS  List of .h files, without path
 HEADERS= $(notdir $(wildcard $(INC)*h))
 # SOURCES  List of .cc files, without path ; this syntax insures there is one .cc file per .h file


### PR DESCRIPTION
This PR removes `--glibs` from the Hector Makefile, in order to avoid potential problems with batch jobs under condor.  Resolves https://github.com/cms-sw/cmssw/issues/33466